### PR TITLE
9 milestone number

### DIFF
--- a/.github/workflows/test-release-notes.yml
+++ b/.github/workflows/test-release-notes.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Generate test release notes
         uses: ./
         with:
-          match-milestone: "^1$"
+          match-milestone: "^1 "
           repository: ${{ github.repository }}
       - name: Show release notes
         run: cat milestone-notes.md

--- a/.github/workflows/test-release-notes.yml
+++ b/.github/workflows/test-release-notes.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Generate test release notes
         uses: ./
         with:
-          version-number: "1"
+          match-milestone: "^1$"
           repository: ${{ github.repository }}
       - name: Show release notes
         run: cat milestone-notes.md

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,12 @@
 name: "Milestone Notes"
-description: "Create a .md file with closed issues based on a milestone that matches a given string."
+description: "Create an .md file with closed issues based on a milestone number or regexp matching its title."
 inputs:
-  version-number:
-    description: "Version number"
-    required: true
+  milestone-number:
+    description: "Milestone number. Either this or match-milestone must be provided. Has precedence if both are."
+    required: false
+    default: "-"
   match-milestone:
-    description: "Regular expression to match milestone title. By default milestones that start with version number."
+    description: "Regular expression to match milestone title. Either this or milestone-number must be provided."
     required: false
     default: "-"
   repository:
@@ -27,9 +28,9 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.version-number }}
-    - ${{ inputs.repository }}
+    - ${{ inputs.milestone-number }}
     - ${{ inputs.match-milestone }}
+    - ${{ inputs.repository }}
     - ${{ inputs.labels }}
     - ${{ inputs.ignore }}
     - ${{ inputs.filename }}

--- a/milestone-notes.rb
+++ b/milestone-notes.rb
@@ -7,32 +7,47 @@ unless ARGV[0]
   puts <<HELP
 no parameters provided, which is probably NOT what was intended
 this script supports the following parameters 
-  0 = version number                     (default: Next)
-  1 = owner/public repo                  (default: UnforgivenPL/milestone-notes)
-  2 = regexp for matching version        (default: "^version-number "; use - to enforce default)
+  0 = milestone number                   (default: -, but either this or regexp must be non-default)
+  1 = regexp for matching version        (default: -, but either this or milestone number must be non-default)
+  2 = owner/public repo                  (default: UnforgivenPL/milestone-notes)
   3 = comma-separated labels to look for (default: enhancement, bug)
   4 = labels to exclude                  (default: invalid, wontfix)
   5 = output filename                    (default: milestone-notes.md)
 HELP
 end
 
-version = ARGV[0] || 'Next'
-owner, repository = (ARGV[1] || 'UnforgivenPL/milestone-notes').split('/')
+milestone_number = ARGV[0] || '-'
+regexp = ARGV[1] || '-'
 
-regexp = Regexp.new(ARGV[2].nil? || ARGV[2]=='-' ? "^#{version} " : ARGV[2])
+puts('either milestone number or regexp MUST be defined') || exit(1) if milestone_number == '-' && regexp == '-'
+regexp = Regexp.new(regexp)
+
+owner, repository = (ARGV[2] || 'UnforgivenPL/milestone-notes').split('/')
 
 labels = Hash[(ARGV[3] || 'enhancement, bug').split(/\s*,\s*/).collect { |s| [s, []] }]
 ignore = (ARGV[4] || 'invalid, wontfix').split(/\s*,\s*/)
 
 filename = ARGV[5] || 'milestone-notes.md'
 
-puts "milestone-notes for #{owner}/#{repository} - version #{version}"
+issues = Github::Client::Issues.new
+
+puts "milestone-notes for #{owner}/#{repository}"
 puts "(accepted labels: #{labels.keys.join(', ')}; ignored: #{ignore.join(', ')})"
+milestone = if milestone_number != '-'
+                 puts "(using milestone number #{milestone_number})"
+                 begin
+                   issues.milestones.get(user: owner, repo: repository, number: milestone_number)
+                 rescue
+                   nil
+                 end
+            else
+                 puts "using milestone matching #{regexp}"
+                 issues.milestones
+                       .list(state: 'all', auto_pagination: true, user: owner, repo: repository)
+                       .find { |m| regexp.match?(m.title) }
+            end
 
-issues = Github::Client::Issues.new(user: owner, repo: repository)
-
-if (milestone = issues.milestones.list(state: 'all', auto_pagination: true)
-                      .find { |m| regexp.match?(m.title) })
+if milestone
   puts "fetching closed issues for milestone <#{milestone.title}>, please wait..."
   to_include = issues.list(milestone: milestone.number,
                            state: 'closed',
@@ -55,5 +70,6 @@ if (milestone = issues.milestones.list(state: 'all', auto_pagination: true)
   puts '...finished;'
   puts 'all done; goodbye!'
 else
-  puts "no milestone matching #{regexp} found for version [#{version}], nothing to do; goodbye"
+  puts "no milestone found matching #{regexp} or number #{milestone_number}"
+  puts "nothing to do; goodbye!"
 end


### PR DESCRIPTION
`version-number` is now gone, `milestone-number` or `match-milestone` must be provided instead

closes #9 